### PR TITLE
Update cachePosts to skip DS_STORE files

### DIFF
--- a/remix.init/gitignore
+++ b/remix.init/gitignore
@@ -9,3 +9,5 @@ node_modules
 .output
 /api
 /app/styles/*.css
+
+.DS_STORE

--- a/scripts/cachePosts.ts
+++ b/scripts/cachePosts.ts
@@ -1,85 +1,100 @@
-import fm from "front-matter";
-import type { BlogPostAttributes } from "../app/types";
-import fs from 'fs/promises'
+import fm from 'front-matter';
+import type { BlogPostAttributes } from '../app/types';
+import fs from 'fs/promises';
 import { watch } from 'fs';
 
 type BlogPost = {
-	attributes: BlogPostAttributes
-	body: string
-	url: string
-}
-
-async function walk(path: string, callback: (path: string, stat: any) => Promise<void> | void): Promise<void> {
-	const results = await fs.readdir(path)
-
-	await Promise.all(results.map(async (fileOrDirectory) => {
-		const filePath = `${path}/${fileOrDirectory}`
-		const stat = await fs.stat(filePath)
-
-		if (stat.isDirectory()) {
-			return walk(filePath, callback)
-		} else {
-			return callback(filePath, stat)
-		}
-	}));
+  attributes: BlogPostAttributes;
+  body: string;
+  url: string;
 };
 
-/*** 
+async function walk(
+  path: string,
+  callback: (path: string, stat: any) => Promise<void> | void
+): Promise<void> {
+  const results = await fs.readdir(path);
+
+  await Promise.all(
+    results.map(async (fileOrDirectory) => {
+      const filePath = `${path}/${fileOrDirectory}`;
+      const stat = await fs.stat(filePath);
+
+      if (stat.isDirectory()) {
+        return walk(filePath, callback);
+      } else {
+        return callback(filePath, stat);
+      }
+    })
+  );
+}
+
+/***
  * build a cache file for each content-type
  * walkPath: the path to read
  * filename: what to save the cache file as
  * urlPath: used for slugs, such as /docs, /posts, etc
-***/
+ ***/
 async function cacheFile(walkPath, filename, urlPath) {
-	let blogPosts: Array<BlogPost> = [];
+  let blogPosts: Array<BlogPost> = [];
 
-	let addFile = async (file: string) => {
-		let frontmatter = fm<BlogPostAttributes>(await fs.readFile(file, 'utf-8'));
-	    let url = '';
+  let addFile = async (file: string) => {
+    let frontmatter = fm<BlogPostAttributes>(await fs.readFile(file, 'utf-8'));
+    let url = '';
 
-		// is this an index.mdx file?
-		if (file.endsWith('index.mdx')) {
-			url = `${urlPath}/${file.substring(walkPath.length + 1, file.length - '/index.mdx'.length)}`;
-		// is this any other mdx file?
-		} else if (file.endsWith('.mdx')) {
-            url = `${urlPath}/${file.substring(walkPath.length + 1, file.length - '.mdx'.length)}`;
-		}
+    //skip any .DS_Store files
+    if (file.endsWith('.DS_Store')) {
+      return;
+    }
+    // is this an index.mdx file?
+    else if (file.endsWith('index.mdx')) {
+      url = `${urlPath}/${file.substring(
+        walkPath.length + 1,
+        file.length - '/index.mdx'.length
+      )}`;
+      // is this any other mdx file?
+    } else if (file.endsWith('.mdx')) {
+      url = `${urlPath}/${file.substring(
+        walkPath.length + 1,
+        file.length - '.mdx'.length
+      )}`;
+    }
 
-		blogPosts.push({
-			attributes: frontmatter.attributes,
-			body: frontmatter.attributes.excerpt.substring(0, 100) + '...',
-			url: url.replace(/\/\//g,"/")
-		});
-	}
+    blogPosts.push({
+      attributes: frontmatter.attributes,
+      body: frontmatter.attributes.excerpt.substring(0, 100) + '...',
+      url: url.replace(/\/\//g, '/'),
+    });
+  };
 
-	await walk(walkPath, addFile);
-	
-	// sort by the date in frontmatter
-	blogPosts = blogPosts.sort((a, z) => {
-		const aTime = new Date(a.attributes.date ?? '').getTime()
-		const zTime = new Date(z.attributes.date ?? '').getTime()
-		return aTime > zTime ? -1 : aTime === zTime ? 0 : 1
-	});
+  await walk(walkPath, addFile);
 
-	await fs.writeFile(filename, JSON.stringify(blogPosts));
+  // sort by the date in frontmatter
+  blogPosts = blogPosts.sort((a, z) => {
+    const aTime = new Date(a.attributes.date ?? '').getTime();
+    const zTime = new Date(z.attributes.date ?? '').getTime();
+    return aTime > zTime ? -1 : aTime === zTime ? 0 : 1;
+  });
+
+  await fs.writeFile(filename, JSON.stringify(blogPosts));
 }
 
 // for each content-type, we can generate a cache json file
 async function getContent() {
-	// posts
-	await cacheFile('./content/posts', './content/blog-cache.json','/blog');
-	// docs
-	await cacheFile('./content/docs', './content/docs-cache.json', '/docs');
-	// pages
-	await cacheFile('./content/pages', './content/page-cache.json','');
+  // posts
+  await cacheFile('./content/posts', './content/blog-cache.json', '/blog');
+  // docs
+  await cacheFile('./content/docs', './content/docs-cache.json', '/docs');
+  // pages
+  await cacheFile('./content/pages', './content/page-cache.json', '');
 }
 
 getContent();
 
 if (process.argv.at(-1) === 'watch') {
-	watch('./content', (eventType, filename) => {
-		if (filename.endsWith('.mdx')) {
-			getContent();
-		}
-	});
+  watch('./content', (eventType, filename) => {
+    if (filename.endsWith('.mdx')) {
+      getContent();
+    }
+  });
 }

--- a/scripts/cachePosts.ts
+++ b/scripts/cachePosts.ts
@@ -1,100 +1,89 @@
-import fm from 'front-matter';
-import type { BlogPostAttributes } from '../app/types';
-import fs from 'fs/promises';
+import fm from "front-matter";
+import type { BlogPostAttributes } from "../app/types";
+import fs from 'fs/promises'
 import { watch } from 'fs';
 
 type BlogPost = {
-  attributes: BlogPostAttributes;
-  body: string;
-  url: string;
-};
-
-async function walk(
-  path: string,
-  callback: (path: string, stat: any) => Promise<void> | void
-): Promise<void> {
-  const results = await fs.readdir(path);
-
-  await Promise.all(
-    results.map(async (fileOrDirectory) => {
-      const filePath = `${path}/${fileOrDirectory}`;
-      const stat = await fs.stat(filePath);
-
-      if (stat.isDirectory()) {
-        return walk(filePath, callback);
-      } else {
-        return callback(filePath, stat);
-      }
-    })
-  );
+	attributes: BlogPostAttributes
+	body: string
+	url: string
 }
 
-/***
+async function walk(path: string, callback: (path: string, stat: any) => Promise<void> | void): Promise<void> {
+	const results = await fs.readdir(path)
+
+	await Promise.all(results.map(async (fileOrDirectory) => {
+		const filePath = `${path}/${fileOrDirectory}`
+		const stat = await fs.stat(filePath)
+
+		if (stat.isDirectory()) {
+			return walk(filePath, callback)
+		} else {
+			return callback(filePath, stat)
+		}
+	}));
+};
+
+/*** 
  * build a cache file for each content-type
  * walkPath: the path to read
  * filename: what to save the cache file as
  * urlPath: used for slugs, such as /docs, /posts, etc
- ***/
+***/
 async function cacheFile(walkPath, filename, urlPath) {
-  let blogPosts: Array<BlogPost> = [];
+	let blogPosts: Array<BlogPost> = [];
 
-  let addFile = async (file: string) => {
-    let frontmatter = fm<BlogPostAttributes>(await fs.readFile(file, 'utf-8'));
-    let url = '';
-
+	let addFile = async (file: string) => {
+		let frontmatter = fm<BlogPostAttributes>(await fs.readFile(file, 'utf-8'));
+	    let url = '';
+    
     //skip any .DS_Store files
     if (file.endsWith('.DS_Store')) {
       return;
     }
-    // is this an index.mdx file?
-    else if (file.endsWith('index.mdx')) {
-      url = `${urlPath}/${file.substring(
-        walkPath.length + 1,
-        file.length - '/index.mdx'.length
-      )}`;
-      // is this any other mdx file?
-    } else if (file.endsWith('.mdx')) {
-      url = `${urlPath}/${file.substring(
-        walkPath.length + 1,
-        file.length - '.mdx'.length
-      )}`;
-    }
+		// is this an index.mdx file?
+		else if (file.endsWith('index.mdx')) {
+			url = `${urlPath}/${file.substring(walkPath.length + 1, file.length - '/index.mdx'.length)}`;
+		// is this any other mdx file?
+		} else if (file.endsWith('.mdx')) {
+            url = `${urlPath}/${file.substring(walkPath.length + 1, file.length - '.mdx'.length)}`;
+		}
 
-    blogPosts.push({
-      attributes: frontmatter.attributes,
-      body: frontmatter.attributes.excerpt.substring(0, 100) + '...',
-      url: url.replace(/\/\//g, '/'),
-    });
-  };
+		blogPosts.push({
+			attributes: frontmatter.attributes,
+			body: frontmatter.attributes.excerpt.substring(0, 100) + '...',
+			url: url.replace(/\/\//g,"/")
+		});
+	}
 
-  await walk(walkPath, addFile);
+	await walk(walkPath, addFile);
+	
+	// sort by the date in frontmatter
+	blogPosts = blogPosts.sort((a, z) => {
+		const aTime = new Date(a.attributes.date ?? '').getTime()
+		const zTime = new Date(z.attributes.date ?? '').getTime()
+		return aTime > zTime ? -1 : aTime === zTime ? 0 : 1
+	});
 
-  // sort by the date in frontmatter
-  blogPosts = blogPosts.sort((a, z) => {
-    const aTime = new Date(a.attributes.date ?? '').getTime();
-    const zTime = new Date(z.attributes.date ?? '').getTime();
-    return aTime > zTime ? -1 : aTime === zTime ? 0 : 1;
-  });
-
-  await fs.writeFile(filename, JSON.stringify(blogPosts));
+	await fs.writeFile(filename, JSON.stringify(blogPosts));
 }
 
 // for each content-type, we can generate a cache json file
 async function getContent() {
-  // posts
-  await cacheFile('./content/posts', './content/blog-cache.json', '/blog');
-  // docs
-  await cacheFile('./content/docs', './content/docs-cache.json', '/docs');
-  // pages
-  await cacheFile('./content/pages', './content/page-cache.json', '');
+	// posts
+	await cacheFile('./content/posts', './content/blog-cache.json','/blog');
+	// docs
+	await cacheFile('./content/docs', './content/docs-cache.json', '/docs');
+	// pages
+	await cacheFile('./content/pages', './content/page-cache.json','');
 }
 
 getContent();
 
 if (process.argv.at(-1) === 'watch') {
-  watch('./content', (eventType, filename) => {
-    if (filename.endsWith('.mdx')) {
-      getContent();
-    }
-  });
+	watch('./content', (eventType, filename) => {
+		if (filename.endsWith('.mdx')) {
+			getContent();
+		}
+	});
 }

--- a/scripts/cachePosts.ts
+++ b/scripts/cachePosts.ts
@@ -37,12 +37,11 @@ async function cacheFile(walkPath, filename, urlPath) {
 		let frontmatter = fm<BlogPostAttributes>(await fs.readFile(file, 'utf-8'));
 	    let url = '';
     
-    //skip any .DS_Store files
-    if (file.endsWith('.DS_Store')) {
-      return;
-    }
+                //skip any .DS_Store files
+               if (file.endsWith('.DS_Store')) {
+                 return;
 		// is this an index.mdx file?
-		else if (file.endsWith('index.mdx')) {
+		} else if (file.endsWith('index.mdx')) {
 			url = `${urlPath}/${file.substring(walkPath.length + 1, file.length - '/index.mdx'.length)}`;
 		// is this any other mdx file?
 		} else if (file.endsWith('.mdx')) {


### PR DESCRIPTION
I randomly started encountering an issue with cachePosts failing with the following:
```js
/cachePosts.ts:54
				body: frontmatter.attributes.excerpt.substring(0, 100) + '...',
                                         ^
TypeError: Cannot read properties of undefined (reading 'substring')
```

Upon further inspection it seemed `cachePosts` was attempting to parse and cache DS_STORE files like `./content/posts/.DS_STORE` and `./content/posts/my-post/.DS_Store`. I updated `cachePosts` to skip processing `DS_STORE` files which seemed to resolve the issue. I am not sure if you have another recommendation for resolving this issue and/or if there are other similar files that should be excluded.